### PR TITLE
Test: UI-1 violations (should be flagged)

### DIFF
--- a/src/pages/test-ui1/AuthCallbackPage.tsx
+++ b/src/pages/test-ui1/AuthCallbackPage.tsx
@@ -1,0 +1,27 @@
+import React, {useEffect} from 'react';
+import {ActivityIndicator, View} from 'react-native';
+import useThemeStyles from '@hooks/useThemeStyles';
+import * as Session from '@userActions/Session';
+import CONST from '@src/CONST';
+
+type AuthCallbackPageProps = {
+    authToken: string;
+};
+
+function AuthCallbackPage({authToken}: AuthCallbackPageProps) {
+    const styles = useThemeStyles();
+
+    useEffect(() => {
+        Session.signInWithToken(authToken);
+    }, [authToken]);
+
+    return (
+        <View style={[styles.flex1, styles.justifyContentCenter, styles.alignItemsCenter]}>
+            <ActivityIndicator size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE} />
+        </View>
+    );
+}
+
+AuthCallbackPage.displayName = 'AuthCallbackPage';
+
+export default AuthCallbackPage;

--- a/src/pages/test-ui1/ValidateAccountPage.tsx
+++ b/src/pages/test-ui1/ValidateAccountPage.tsx
@@ -1,0 +1,27 @@
+import React, {useEffect} from 'react';
+import FullscreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+import ScreenWrapper from '@components/ScreenWrapper';
+import Navigation from '@libs/Navigation/Navigation';
+import * as Session from '@userActions/Session';
+import ROUTES from '@src/ROUTES';
+
+type ValidateAccountPageProps = {
+    accountID: number;
+    validateCode: string;
+};
+
+function ValidateAccountPage({accountID, validateCode}: ValidateAccountPageProps) {
+    useEffect(() => {
+        Session.validateAccount(accountID, validateCode);
+    }, [accountID, validateCode]);
+
+    return (
+        <ScreenWrapper testID="ValidateAccountPage">
+            <FullscreenLoadingIndicator />
+        </ScreenWrapper>
+    );
+}
+
+ValidateAccountPage.displayName = 'ValidateAccountPage';
+
+export default ValidateAccountPage;

--- a/src/pages/test-ui1/WorkspaceSubscriptionPage.tsx
+++ b/src/pages/test-ui1/WorkspaceSubscriptionPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {View} from 'react-native';
+import FullscreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import ScreenWrapper from '@components/ScreenWrapper';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import Navigation from '@libs/Navigation/Navigation';
+import ROUTES from '@src/ROUTES';
+
+type WorkspaceSubscriptionPageProps = {
+    policyID: string;
+};
+
+function WorkspaceSubscriptionPage({policyID}: WorkspaceSubscriptionPageProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const isLoading = true; // simplified for test
+
+    return (
+        <ScreenWrapper testID="WorkspaceSubscriptionPage">
+            <HeaderWithBackButton
+                title={translate('workspace.common.subscription')}
+                onBackButtonPress={() => Navigation.goBack(ROUTES.SETTINGS)}
+            />
+            <View style={[styles.flex1]}>
+                {isLoading && <FullscreenLoadingIndicator />}
+                {!isLoading && (
+                    <View>
+                        {/* Subscription content */}
+                    </View>
+                )}
+            </View>
+        </ScreenWrapper>
+    );
+}
+
+WorkspaceSubscriptionPage.displayName = 'WorkspaceSubscriptionPage';
+
+export default WorkspaceSubscriptionPage;


### PR DESCRIPTION
## Purpose
Test PR to verify the AI reviewer correctly **flags** UI-1 violations.

## Expected reviewer behavior
All 3 files should receive inline comments:

| File | Violation | Expected comment |
|------|-----------|-----------------|
| `WorkspaceSubscriptionPage.tsx` | `FullscreenLoadingIndicator` + `HeaderWithBackButton` in same JSX tree | Should use `ActivityIndicator` instead |
| `ValidateAccountPage.tsx` | `FullscreenLoadingIndicator` without `shouldUseGoBackButton`, no navigation | Missing `shouldUseGoBackButton` prop |
| `AuthCallbackPage.tsx` | `ActivityIndicator` as sole screen content, no navigation | Should use `FullscreenLoadingIndicator` with `shouldUseGoBackButton` |